### PR TITLE
Fix some translations

### DIFF
--- a/languages/zh.json
+++ b/languages/zh.json
@@ -1,14 +1,14 @@
 {
   "fullLangName": "Chinese",
-  "appName": "割草机启动器",
+  "appName": "GrassClipper启动器",
 
-  "playOfficial": "启动官方服务器",
-  "playPrivate": "启动私人服务器",
+  "playOfficial": "游玩官方服务器",
+  "playPrivate": "游玩私人服务器",
   "launchLocalServer": "启动本地服务器",
 
-  "genshinFolderSet": "设置 \"Genshin Impact Game\" 文件夹",
-  "grasscutterFileSet": "设置 \"GrassCutter\" .jar 文件",
-  "folderNotSet": "没有设置启动文件夹或文件",
+  "genshinFolderSet": "选择 \"原神\" 文件夹",
+  "grasscutterFileSet": "选择 \"GrassCutter\" .jar 文件",
+  "folderNotSet": "没有设置原神文件夹或GrassCutter文件",
 
   "ipPlaceholder": "IP地址",
   "noFavorites": "没有收藏",
@@ -16,7 +16,7 @@
   "settingsTitle": "设置",
   "scriptsSectionTitle": "进程",
   "killswitchOption": "杀死服务进程",
-  "killswitchSubtitle": "如果IE代理发生了一些错误，启用此选项可以杀死服务进程和你的网络连接。",
+  "killswitchSubtitle": "仅为那些害怕被封号的人准备。此选项可以结束游戏进程(还可以让你断网，如果修改了代理设置的话)。",
   "proxyOption": "代理",
   "proxySubtitle": "通过安装脚本安装代理服务器。",
   "updateOption": "更新",
@@ -26,8 +26,8 @@
   "enableServerLauncherOption": "启用本地服务器",
   "enableServerLauncherSubtitle": "启动器内为你显示启动本地服务器选项。",
 
-  "introSen1": "看来这是你第一次使用割草机启动器！",
-  "introSen2": "首先，欢迎你使用割草机启动器，其次很高兴在这里见到你！ :)",
+  "introSen1": "看来这是你第一次使用GrassClipper启动器！",
+  "introSen2": "首先，欢迎你使用GrassClipper启动器，其次很高兴在这里见到你！ :)",
   "introSen3": "是否要运行代理安装程序？",
   "introSen4": "（需要连接到专用服务器）",
 

--- a/languages/zh.json
+++ b/languages/zh.json
@@ -29,11 +29,11 @@
   "introSen1": "看来这是你第一次使用GrassClipper启动器！",
   "introSen2": "首先，欢迎你使用GrassClipper启动器，其次很高兴在这里见到你！ :)",
   "introSen3": "是否要运行代理安装程序？",
-  "introSen4": "（需要连接到专用服务器）",
+  "introSen4": "（需要连接到私人服务器）",
 
   "proxyInstallBtn": "安装",
   "proxyInstallDeny": "不用了，谢谢",
 
-  "genshinFolderDialog": "选择Genshin Impact Game文件夹",
+  "genshinFolderDialog": "选择原神文件夹",
   "grasscutterFileDialog": "选择GrassCutter服务器jar文件"
 }


### PR DESCRIPTION
1 ：I think "GrassClipper" is a proper noun，its inappropriate to translate it literally.
2："Play(游玩)" is not "launch(启动)".
3：“Genshin Impact Game（原神）” is not translated.
4："killswitchSubtitle" is completely wrong and seems like machine translate.
5：“set” here is preferably translated as "选择(select)"
6: Change some expressions of "folderNotSet" to let it looks clearer